### PR TITLE
Make pack format support versions 1.20.2+

### DIFF
--- a/src/main/resources/resourcepacks/blocking_predicates/pack.mcmeta
+++ b/src/main/resources/resourcepacks/blocking_predicates/pack.mcmeta
@@ -1,6 +1,11 @@
 {
   "pack": {
     "pack_format": 12,
+    "_comment_": "'supported_formats' only works for 1.20.2+",
+    "supported_formats": {
+      "min_inclusive": 12,
+      "max_inclusive": 100
+    },
     "description": "§2Provides the required predicates for Sword Blocking"
   }
 }


### PR DESCRIPTION
Make pack format support versions 1.20.2+ by adding "supported_formats" key to the pack meta, and range 12 - 100.