### PR TITLE
Update to 1.21.4 + New Features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
-    id "dev.architectury.loom" version "1.6-SNAPSHOT" apply false
+    id "dev.architectury.loom" version "1.7-SNAPSHOT" apply false
     id "me.shedaniel.unified-publishing" version "0.1.+" apply false
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
 }

--- a/common/src/main/java/eu/midnightdust/swordblocking/SwordBlockingClient.java
+++ b/common/src/main/java/eu/midnightdust/swordblocking/SwordBlockingClient.java
@@ -1,36 +1,36 @@
 package eu.midnightdust.swordblocking;
 
 import eu.midnightdust.swordblocking.config.SwordBlockingConfig;
-import net.minecraft.component.DataComponentTypes;
+import net.minecraft.client.render.entity.state.BipedEntityRenderState;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.item.AxeItem;
-import net.minecraft.item.Item;
-import net.minecraft.item.MaceItem;
-import net.minecraft.item.ShieldItem;
-import net.minecraft.item.SwordItem;
+import net.minecraft.item.*;
 
-import java.util.Objects;
+import java.util.HashMap;
+import java.util.Map;
 
 public class SwordBlockingClient {
     public static final String MOD_ID = "swordblocking";
+    public static Map<BipedEntityRenderState, LivingEntity> RENDER_STATE_TO_ENTITY_MAP = new HashMap<>();
 
     public static void init() {
         SwordBlockingConfig.init(MOD_ID, SwordBlockingConfig.class);
     }
 
-    public static boolean isWeaponBlocking(LivingEntity entity) {
-        return entity.isUsingItem() && (canWeaponBlock(entity) || isBlockingOnViaVersion(entity));
+    public static boolean isEntityBlocking(LivingEntity entity) {
+        return entity.isUsingItem() && canShieldSwordBlock(entity);
     }
 
-    public static boolean canWeaponBlock(LivingEntity entity) {
+    public static boolean canShieldSwordBlock(LivingEntity entity) {
         if (SwordBlockingConfig.enabled && (entity.getOffHandStack().getItem() instanceof ShieldItem || entity.getMainHandStack().getItem() instanceof ShieldItem)) {
             Item weaponItem = entity.getOffHandStack().getItem() instanceof ShieldItem ? entity.getMainHandStack().getItem() : entity.getOffHandStack().getItem();
             return weaponItem instanceof SwordItem || weaponItem instanceof AxeItem || weaponItem instanceof MaceItem;
+        } else {
+            return false;
         }
-        return false;
     }
-    public static boolean isBlockingOnViaVersion(LivingEntity entity) {
-        Item item = entity.getMainHandStack().getItem() instanceof SwordItem ? entity.getMainHandStack().getItem() : entity.getOffHandStack().getItem();
-        return item instanceof SwordItem && item.getComponents() != null && item.getComponents().contains(DataComponentTypes.FOOD) && Objects.requireNonNull(item.getComponents().get(DataComponentTypes.FOOD)).eatSeconds() == 3600;
+
+    public static boolean shouldHideShield(LivingEntity entity, ItemStack stack) {
+        return (SwordBlockingConfig.alwaysHideShield && SwordBlockingConfig.hideShield && stack.getItem() instanceof ShieldItem)
+                || (SwordBlockingConfig.hideShield && stack.getItem() instanceof ShieldItem && SwordBlockingClient.canShieldSwordBlock(entity));
     }
 }

--- a/common/src/main/java/eu/midnightdust/swordblocking/SwordBlockingClient.java
+++ b/common/src/main/java/eu/midnightdust/swordblocking/SwordBlockingClient.java
@@ -17,7 +17,7 @@ public class SwordBlockingClient {
     }
 
     public static boolean isEntityBlocking(LivingEntity entity) {
-        return entity.isUsingItem() && canShieldSwordBlock(entity);
+        return SwordBlockingConfig.enabled && entity.isUsingItem() && canShieldSwordBlock(entity);
     }
 
     public static boolean canShieldSwordBlock(LivingEntity entity) {
@@ -30,7 +30,7 @@ public class SwordBlockingClient {
     }
 
     public static boolean shouldHideShield(LivingEntity entity, ItemStack stack) {
-        return (SwordBlockingConfig.alwaysHideShield && SwordBlockingConfig.hideShield && stack.getItem() instanceof ShieldItem)
+        return SwordBlockingConfig.enabled && (SwordBlockingConfig.alwaysHideShield && SwordBlockingConfig.hideShield && stack.getItem() instanceof ShieldItem)
                 || (SwordBlockingConfig.hideShield && stack.getItem() instanceof ShieldItem && SwordBlockingClient.canShieldSwordBlock(entity));
     }
 }

--- a/common/src/main/java/eu/midnightdust/swordblocking/config/SwordBlockingConfig.java
+++ b/common/src/main/java/eu/midnightdust/swordblocking/config/SwordBlockingConfig.java
@@ -7,4 +7,7 @@ public class SwordBlockingConfig extends MidnightConfig {
     @Entry public static boolean hideShield = true;
     @Entry public static boolean alwaysHideShield = true;
     @Entry public static boolean hideOffhandSlot = false;
+    @Entry public static boolean disableUseEquipAnimation = false;
+    @Entry public static boolean lockBlockingArmPosition = false;
+    @Entry public static boolean blockHitAnimation = false;
 }

--- a/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinBipedEntityModel.java
+++ b/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinBipedEntityModel.java
@@ -24,7 +24,7 @@ public abstract class MixinBipedEntityModel<T extends BipedEntityRenderState> {
     @Inject(method = "setAngles(Lnet/minecraft/client/render/entity/state/BipedEntityRenderState;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/model/BipedEntityModel;animateArms(Lnet/minecraft/client/render/entity/state/BipedEntityRenderState;F)V", shift = At.Shift.BEFORE))
     private void swordBlocking$setBlockingAngles(T bipedEntityRenderState, CallbackInfo ci) {
         LivingEntity livingEntity = SwordBlockingClient.RENDER_STATE_TO_ENTITY_MAP.get(bipedEntityRenderState);
-        if (!SwordBlockingConfig.enabled || livingEntity == null || !SwordBlockingClient.isEntityBlocking(livingEntity))
+        if (livingEntity == null || !SwordBlockingClient.isEntityBlocking(livingEntity))
             return;
         if (livingEntity.getOffHandStack().getItem() instanceof ShieldItem)
             this.positionRightArm(bipedEntityRenderState, BipedEntityModel.ArmPose.BLOCK);

--- a/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinBipedEntityModel.java
+++ b/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinBipedEntityModel.java
@@ -1,27 +1,43 @@
 package eu.midnightdust.swordblocking.mixin;
 
 import eu.midnightdust.swordblocking.SwordBlockingClient;
+import eu.midnightdust.swordblocking.config.SwordBlockingConfig;
 import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.client.render.entity.state.BipedEntityRenderState;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ShieldItem;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BipedEntityModel.class)
-public abstract class MixinBipedEntityModel<T extends LivingEntity> {
-    @Shadow protected abstract void positionRightArm(T entity);
+public abstract class MixinBipedEntityModel<T extends BipedEntityRenderState> {
+    @Shadow
+    protected abstract void positionRightArm(T entityRenderState, BipedEntityModel.ArmPose armPose);
 
-    @Shadow protected abstract void positionLeftArm(T entity);
+    @Shadow
+    protected abstract void positionLeftArm(T entityRenderState, BipedEntityModel.ArmPose armPose);
 
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/model/BipedEntityModel;animateArms(Lnet/minecraft/entity/LivingEntity;F)V", shift = At.Shift.BEFORE), method = "setAngles(Lnet/minecraft/entity/LivingEntity;FFFFF)V")
-    private void swordblocking$setBlockingAngles(T livingEntity, float f, float g, float h, float i, float j, CallbackInfo ci) {
-        if (!SwordBlockingClient.isWeaponBlocking(livingEntity))
+    @Inject(method = "setAngles(Lnet/minecraft/client/render/entity/state/BipedEntityRenderState;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/model/BipedEntityModel;animateArms(Lnet/minecraft/client/render/entity/state/BipedEntityRenderState;F)V", shift = At.Shift.BEFORE))
+    private void swordBlocking$setBlockingAngles(T bipedEntityRenderState, CallbackInfo ci) {
+        LivingEntity livingEntity = SwordBlockingClient.RENDER_STATE_TO_ENTITY_MAP.get(bipedEntityRenderState);
+        if (!SwordBlockingConfig.enabled || livingEntity == null || !SwordBlockingClient.isEntityBlocking(livingEntity))
             return;
         if (livingEntity.getOffHandStack().getItem() instanceof ShieldItem)
-            this.positionRightArm(livingEntity);
+            this.positionRightArm(bipedEntityRenderState, BipedEntityModel.ArmPose.BLOCK);
         else
-            this.positionLeftArm(livingEntity);
+            this.positionLeftArm(bipedEntityRenderState, BipedEntityModel.ArmPose.BLOCK);
+    }
+
+    @Redirect(method = "positionBlockingArm", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;clamp(FFF)F"))
+    private float swordBlocking$lockArmPosition(float value, float min, float max) {
+        if (SwordBlockingConfig.enabled && SwordBlockingConfig.lockBlockingArmPosition) {
+            return 0F;
+        } else {
+            return value;
+        }
     }
 }

--- a/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinBipedEntityRenderer.java
+++ b/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinBipedEntityRenderer.java
@@ -1,0 +1,21 @@
+package eu.midnightdust.swordblocking.mixin;
+
+import eu.midnightdust.swordblocking.SwordBlockingClient;
+import net.minecraft.client.item.ItemModelManager;
+import net.minecraft.client.render.entity.BipedEntityRenderer;
+import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.client.render.entity.state.BipedEntityRenderState;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.MobEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BipedEntityRenderer.class)
+public abstract class MixinBipedEntityRenderer<T extends MobEntity, S extends BipedEntityRenderState, M extends BipedEntityModel<S>> {
+    @Inject(method = "updateBipedRenderState", at = @At("TAIL"))
+    private static void swordBlocking$storeEntity(LivingEntity entity, BipedEntityRenderState state, float tickDelta, ItemModelManager itemModelResolver, CallbackInfo ci) {
+        SwordBlockingClient.RENDER_STATE_TO_ENTITY_MAP.put(state, entity);
+    }
+}

--- a/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinHeldItemFeatureRenderer.java
+++ b/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinHeldItemFeatureRenderer.java
@@ -1,0 +1,31 @@
+package eu.midnightdust.swordblocking.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import eu.midnightdust.swordblocking.SwordBlockingClient;
+import eu.midnightdust.swordblocking.config.SwordBlockingConfig;
+import net.minecraft.client.render.entity.feature.HeldItemFeatureRenderer;
+import net.minecraft.client.render.entity.model.EntityModel;
+import net.minecraft.client.render.entity.model.ModelWithArms;
+import net.minecraft.client.render.entity.state.ArmedEntityRenderState;
+import net.minecraft.client.render.item.ItemRenderState;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Arm;
+import net.minecraft.util.Hand;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(HeldItemFeatureRenderer.class)
+public abstract class MixinHeldItemFeatureRenderer<S extends ArmedEntityRenderState, M extends EntityModel<S> & ModelWithArms> {
+    @Redirect(method = "renderItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/ItemRenderState;isEmpty()Z"))
+    private boolean swordBlocking$hideShield(ItemRenderState instance, @Local(argsOnly = true) Arm arm, @Local(argsOnly = true) S entityState) {
+        LivingEntity livingEntity = SwordBlockingClient.RENDER_STATE_TO_ENTITY_MAP.get(entityState);
+        if (SwordBlockingConfig.enabled && livingEntity != null) {
+            ItemStack itemStack = livingEntity.getStackInHand(arm == Arm.LEFT ? Hand.OFF_HAND : Hand.MAIN_HAND);
+            return SwordBlockingClient.shouldHideShield(livingEntity, itemStack);
+        }
+
+        return instance.isEmpty();
+    }
+}

--- a/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinHeldItemRenderer.java
+++ b/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinHeldItemRenderer.java
@@ -34,7 +34,7 @@ public abstract class MixinHeldItemRenderer {
 
     @Inject(method = "renderItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/item/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At("HEAD"), cancellable = true)
     public void swordBlocking$hideShield(LivingEntity entity, ItemStack stack, ModelTransformationMode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        if (SwordBlockingConfig.enabled && SwordBlockingClient.shouldHideShield(entity, stack)) {
+        if (SwordBlockingClient.shouldHideShield(entity, stack)) {
             ci.cancel();
         }
     }
@@ -42,7 +42,7 @@ public abstract class MixinHeldItemRenderer {
     @Redirect(method = "renderFirstPersonItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/AbstractClientPlayerEntity;getActiveHand()Lnet/minecraft/util/Hand;", ordinal = 1))
     private Hand swordBlocking$changeActiveHand(AbstractClientPlayerEntity player, @Local(name = "hand") Hand hand) {
         Hand activeHand = player.getActiveHand();
-        if (SwordBlockingConfig.enabled && SwordBlockingClient.isEntityBlocking(player)) {
+        if (SwordBlockingClient.isEntityBlocking(player)) {
             return swordBlocking$getBlockingHand(activeHand);
         } else {
             return activeHand;
@@ -52,7 +52,7 @@ public abstract class MixinHeldItemRenderer {
     @Redirect(method = "renderFirstPersonItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/item/consume/UseAction;"))
     private UseAction swordBlocking$changeItemAction(ItemStack stack, @Local(argsOnly = true) AbstractClientPlayerEntity player, @Local(name = "hand") Hand hand) {
         UseAction defaultUseAction = stack.getUseAction();
-        if (SwordBlockingConfig.enabled && SwordBlockingClient.isEntityBlocking(player)) {
+        if (SwordBlockingClient.isEntityBlocking(player)) {
             return swordBlocking$getBlockingHand(player.getActiveHand()) == hand ? UseAction.BLOCK : defaultUseAction;
         } else {
             return defaultUseAction;

--- a/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinInGameHud.java
+++ b/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinInGameHud.java
@@ -11,7 +11,11 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(InGameHud.class)
 public abstract class MixinInGameHud {
     @ModifyExpressionValue(at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;getOffHandStack()Lnet/minecraft/item/ItemStack;"), method = "renderHotbarVanilla")
-    public ItemStack swordblocking$hideOffHandSlot(ItemStack original) {
-        return (SwordBlockingConfig.enabled && SwordBlockingConfig.hideOffhandSlot && original.getItem() instanceof ShieldItem) ? ItemStack.EMPTY : original;
+    public ItemStack swordBlocking$hideOffHandSlot(ItemStack original) {
+        if (SwordBlockingConfig.enabled && SwordBlockingConfig.hideOffhandSlot && original.getItem() instanceof ShieldItem) {
+            return ItemStack.EMPTY;
+        } else {
+            return original;
+        }
     }
 }

--- a/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinPlayerEntityRenderer.java
+++ b/common/src/main/java/eu/midnightdust/swordblocking/mixin/MixinPlayerEntityRenderer.java
@@ -4,9 +4,9 @@ import eu.midnightdust.swordblocking.SwordBlockingClient;
 import eu.midnightdust.swordblocking.config.SwordBlockingConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.render.entity.PlayerEntityRenderer;
 import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ShieldItem;
 import net.minecraft.util.Hand;
@@ -17,20 +17,19 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PlayerEntityRenderer.class)
 public abstract class MixinPlayerEntityRenderer {
-    @Inject(at = @At(value = "RETURN"), method = "getArmPose", cancellable = true)
     @Environment(EnvType.CLIENT)
-    private static void swordblocking$getArmPose(AbstractClientPlayerEntity player, Hand hand, CallbackInfoReturnable<BipedEntityModel.ArmPose> cir) {
-        if (!SwordBlockingConfig.enabled) return;
-
-        ItemStack handStack = player.getStackInHand(hand);
-        ItemStack offStack = player.getStackInHand(hand.equals(Hand.MAIN_HAND) ? Hand.OFF_HAND : Hand.MAIN_HAND);
-        if (!SwordBlockingConfig.alwaysHideShield && (handStack.getItem() instanceof ShieldItem) && !SwordBlockingClient.canWeaponBlock(player))
-            return;
-
-        if (offStack.getItem() instanceof ShieldItem && SwordBlockingClient.isWeaponBlocking(player)) {
-            cir.setReturnValue(BipedEntityModel.ArmPose.BLOCK);
-        } else if (handStack.getItem() instanceof ShieldItem && SwordBlockingConfig.hideShield && (cir.getReturnValue() == BipedEntityModel.ArmPose.ITEM || cir.getReturnValue() == BipedEntityModel.ArmPose.BLOCK)) {
-            cir.setReturnValue(BipedEntityModel.ArmPose.EMPTY);
+    @Inject(method = "getArmPose(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/Hand;)Lnet/minecraft/client/render/entity/model/BipedEntityModel$ArmPose;", at = @At(value = "RETURN"), cancellable = true)
+    private static void swordBlocking$getArmPose(PlayerEntity player, ItemStack stack, Hand hand, CallbackInfoReturnable<BipedEntityModel.ArmPose> cir) {
+        if (SwordBlockingConfig.enabled) {
+            ItemStack handStack = player.getStackInHand(hand);
+            ItemStack offStack = player.getStackInHand(hand.equals(Hand.MAIN_HAND) ? Hand.OFF_HAND : Hand.MAIN_HAND);
+            if (!SwordBlockingConfig.alwaysHideShield && (handStack.getItem() instanceof ShieldItem) && !SwordBlockingClient.canShieldSwordBlock(player))
+                return;
+            if (offStack.getItem() instanceof ShieldItem && SwordBlockingClient.isEntityBlocking(player)) {
+                cir.setReturnValue(BipedEntityModel.ArmPose.BLOCK);
+            } else if (handStack.getItem() instanceof ShieldItem && SwordBlockingConfig.hideShield && (cir.getReturnValue() == BipedEntityModel.ArmPose.ITEM || cir.getReturnValue() == BipedEntityModel.ArmPose.BLOCK)) {
+                cir.setReturnValue(BipedEntityModel.ArmPose.EMPTY);
+            }
         }
     }
 }

--- a/common/src/main/resources/assets/swordblocking/lang/en_us.json
+++ b/common/src/main/resources/assets/swordblocking/lang/en_us.json
@@ -4,5 +4,8 @@
   "swordblocking.midnightconfig.hideShield": "Hide Shield",
   "swordblocking.midnightconfig.alwaysHideShield": "Always Hide Shield",
   "swordblocking.midnightconfig.hideOffhandSlot": "Hide Offhand Slot",
-  "swordblocking.midnightconfig.hideOffhandSlot.tooltip": "Hides the offhand slot when a shield is in the offhand."
+  "swordblocking.midnightconfig.hideOffhandSlot.tooltip": "Hides the offhand slot when a shield is in the offhand.",
+  "swordblocking.midnightconfig.disableUseEquipAnimation": "Remove the equip animation when blocking.",
+  "swordblocking.midnightconfig.lockBlockingArmPosition": "Disable arm moving when blocking.",
+  "swordblocking.midnightconfig.blockHitAnimation": "Enable block hitting animation."
 }

--- a/common/src/main/resources/assets/swordblocking/lang/ru_ru.json
+++ b/common/src/main/resources/assets/swordblocking/lang/ru_ru.json
@@ -4,5 +4,8 @@
   "swordblocking.midnightconfig.hideShield": "Спрятать щит",
   "swordblocking.midnightconfig.alwaysHideShield": "Всегда прятать щит",
   "swordblocking.midnightconfig.hideOffhandSlot": "Скрывать слот второй руки",
-  "swordblocking.midnightconfig.hideOffhandSlot.tooltip": "Скрывает слот второй руки, если в ней находится щит."
+  "swordblocking.midnightconfig.hideOffhandSlot.tooltip": "Скрывает слот второй руки, если в ней находится щит.",
+  "swordblocking.midnightconfig.disableUseEquipAnimation": "Удалять анимацию оснащения при блокировании.",
+  "swordblocking.midnightconfig.lockBlockingArmPosition": "Отключить движение руки при блокировании.",
+  "swordblocking.midnightconfig.blockHitAnimation": "Включить анимацию удара по блоку."
 }

--- a/common/src/main/resources/swordblocking.mixins.json
+++ b/common/src/main/resources/swordblocking.mixins.json
@@ -1,15 +1,17 @@
 {
-  "required": true,
-  "minVersion": "0.8",
-  "package": "eu.midnightdust.swordblocking.mixin",
-  "compatibilityLevel": "JAVA_17",
-  "client": [
-    "MixinPlayerEntityRenderer",
-    "MixinBipedEntityModel",
-    "MixinInGameHud",
-    "MixinHeldItemRenderer"
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  }
+	"required": true,
+	"minVersion": "0.8",
+	"package": "eu.midnightdust.swordblocking.mixin",
+	"compatibilityLevel": "JAVA_17",
+	"client": [
+		"MixinBipedEntityModel",
+		"MixinBipedEntityRenderer",
+		"MixinHeldItemFeatureRenderer",
+		"MixinHeldItemRenderer",
+		"MixinInGameHud",
+		"MixinPlayerEntityRenderer"
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -1,37 +1,32 @@
 {
-  "schemaVersion": 1,
-  "id": "swordblocking",
-  "version": "${version}",
-
-  "name": "Sword Blocking",
-  "description": "Adds sword blocking to new versions, you just need a shield in your offhand (or ViaVersion)!",
-  "authors": [
-    "Motschen",
-    "TeamMidnightDust",
-    "lowercasebtw"
-  ],
-  "contact": {
-    "homepage": "https://www.midnightdust.eu/",
-    "sources": "https://github.com/TeamMidnightDust/SwordBlocking",
-    "issues": "https://github.com/TeamMidnightDust/SwordBlocking/issues"
-  },
-
-  "license": "MIT",
-  "icon": "assets/swordblocking/icon.png",
-
-  "environment": "client",
-  "entrypoints": {
-    "client": [
-      "eu.midnightdust.swordblocking.fabric.SwordBlockingClientFabric"
-    ]
-  },
-
-  "mixins": [
-    "swordblocking.mixins.json"
-  ],
-
-  "depends": {
-    "fabric-api": "*",
-    "midnightlib": "*"
-  }
+	"schemaVersion": 1,
+	"id": "swordblocking",
+	"version": "${version}",
+	"name": "Sword Blocking",
+	"description": "Adds sword blocking to new versions, you just need a shield in your offhand (or ViaVersion)!",
+	"authors": [
+		"Motschen",
+		"TeamMidnightDust",
+		"lowercasebtw"
+	],
+	"contact": {
+		"homepage": "https://www.midnightdust.eu/",
+		"sources": "https://github.com/TeamMidnightDust/SwordBlocking",
+		"issues": "https://github.com/TeamMidnightDust/SwordBlocking/issues"
+	},
+	"license": "MIT",
+	"icon": "assets/swordblocking/icon.png",
+	"environment": "client",
+	"entrypoints": {
+		"client": [
+			"eu.midnightdust.swordblocking.fabric.SwordBlockingClientFabric"
+		]
+	},
+	"mixins": [
+		"swordblocking.mixins.json"
+	],
+	"depends": {
+		"fabric-api": "*",
+		"midnightlib": "*"
+	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,24 +1,24 @@
+org.gradle.jvmargs=-Xmx3G
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx2048M
 
-minecraft_version=1.21
-yarn_mappings=1.21+build.2
+# Game Version
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.1
+yarn_mappings_patch_neoforge_version=1.21+build.4
 enabled_platforms=fabric,neoforge
 
+# Dependencies
+midnightlib_version=1.6.6
+
+fabric_loader_version=0.16.9
+fabric_api_version=0.111.0+1.21.4
+
+neoforge_version=21.4.9-beta
+
+# Information
 archives_base_name=swordblocking
-mod_version=2.1.0
+mod_version=2.2.0
 maven_group=eu.midnightdust
 release_type=release
 curseforge_id=427738
 modrinth_id=4q52b4lD
-
-midnightlib_version=1.5.7
-
-fabric_loader_version=0.15.11
-fabric_api_version=0.100.1+1.21
-
-neoforge_version=21.0.14-beta
-yarn_mappings_patch_neoforge_version = 1.21+build.4
-
-quilt_loader_version=0.19.0-beta.18
-quilt_fabric_api_version=7.0.1+0.83.0-1.20

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -10,7 +10,6 @@ repositories {
     }
 }
 
-
 architectury {
     platformSetupLoomIde()
     neoForge()


### PR DESCRIPTION
Added some new config settings & updated to 1.21.4
- Block hitting animation, applies the swing offset on use which restores the block hitting animation from 1.7
- Lock arm position when blocking, undoes the change in 1.20.2 which moves the arm based on head yaw/pitch
- Remove equip animation, in 1.9+ upon blocking, the equip animation would play which looks wrong to many/most don't like it, so this will allow you to disable that.

Removed quilt from gradle.settings, code for viaversion, and general code cleanup.

Bumped mod version to 2.2.0